### PR TITLE
Send date string through as structured dateDisplayDate when unparseable

### DIFF
--- a/lib/collectionspace/tools/date_parser.rb
+++ b/lib/collectionspace/tools/date_parser.rb
@@ -42,7 +42,7 @@ module CollectionSpace
 
       def self.parse(date_string, end_date_string = nil)
         begin
-          unprocessed_date_string = date_string.clone
+          unprocessed_date_string = date_string
           date_string = date_string.strip
           date_increment = :day
           if date_string =~ /^\d{4}$/

--- a/lib/collectionspace/tools/date_parser.rb
+++ b/lib/collectionspace/tools/date_parser.rb
@@ -64,7 +64,7 @@ module CollectionSpace
               DateTime.parse(end_date_string) : parsed_earliest_date + 1.send(date_increment)
             date = StructuredDate.new
 
-            date.computed = true
+            date.computed = 'true'
             date.parsed_datetime = parsed_earliest_date
             date.date_string = unprocessed_date_string
             date.display_date = unprocessed_date_string
@@ -81,7 +81,7 @@ module CollectionSpace
             date
         rescue StandardError
           date = StructuredDate.new
-          date.computed = false
+          date.computed = 'false'
           date.display_date = unprocessed_date_string
           date
         end

--- a/spec/collectionspace/tools/date_parser_spec.rb
+++ b/spec/collectionspace/tools/date_parser_spec.rb
@@ -8,11 +8,34 @@ RSpec.describe CSDTP do
     let(:hyphenated_date) { '1905-1907' }
     let(:usa_date) { '11/02/1980' }
     let(:short_month_or_day_date) { '2010/1/1' }
+    let(:ca_date) { 'ca. 1950' }
+    let(:text_date) { 'Early 20th century' }
 
     it "can return an empty date when no date provided" do
       date = CSDTP.parse(nil)
       expect(date.class).to eq CollectionSpace::Tools::StructuredDate
       expect(date.parsed_datetime).to be nil
+    end
+
+    context 'when approximate date or textual date string given' do
+      let(:ca_date_parsed) { CSDTP.parse(ca_date) }
+      let(:text_date_parsed) {CSDTP.parse(text_date) }
+      
+      it "returns structured date" do
+        pp(ca_date_parsed)
+        pp(CSDTP.fields_for(ca_date_parsed))
+           
+      expect(ca_date_parsed.class).to eq CollectionSpace::Tools::StructuredDate
+      expect(text_date_parsed.class).to eq CollectionSpace::Tools::StructuredDate
+    end
+    it "scalarValuesComputed = false" do
+      expect(ca_date_parsed.computed).to be false
+      expect(text_date_parsed.computed).to be false
+    end
+    it "dateDisplayDate = the date string passed in" do
+      expect(ca_date_parsed.display_date).to eq(ca_date)
+      expect(text_date_parsed.display_date).to eq(text_date)
+    end
     end
 
     it "can parse a basic date" do

--- a/spec/collectionspace/tools/date_parser_spec.rb
+++ b/spec/collectionspace/tools/date_parser_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe CSDTP do
       expect(text_date_parsed.class).to eq CollectionSpace::Tools::StructuredDate
     end
     it "scalarValuesComputed = false" do
-      expect(ca_date_parsed.computed).to be false
-      expect(text_date_parsed.computed).to be false
+      expect(ca_date_parsed.computed).to eq 'false'
+      expect(text_date_parsed.computed).to eq 'false'
     end
     it "dateDisplayDate = the date string passed in" do
       expect(ca_date_parsed.display_date).to eq(ca_date)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -45,6 +45,7 @@ module Helpers
   end
 
   def test_base_basic_date(date)
+    expect(date.computed).to eq 'true'
     expect(date.parsed_datetime.to_s).to eq '2011-11-02T00:00:00+00:00'
     expect(date.date_string).to eq basic_date
     expect(date.earliest_day).to eq 2


### PR DESCRIPTION
Fixes #188 

It looks like Mark made a change in this direction yesterday, but when I wrote tests for it, they failed. 

Right now, if passed "ca. 1950" as a date string, this produces: 

for .parse:

```
<struct CollectionSpace::Tools::StructuredDate
 computed=false,
 parsed_datetime=nil,
 date_string=nil,
 display_date="ca. 1950",
 earliest_day=nil,
 earliest_month=nil,
 earliest_year=nil,
 earliest_scalar=nil,
 latest_day=nil,
 latest_month=nil,
 latest_year=nil,
 latest_scalar=nil>
```

for .dates_for(parsed_date):

```
{"scalarValuesComputed"=>false,
 "dateDisplayDate"=>"ca. 1950",
 "dateEarliestSingleYear"=>nil,
 "dateEarliestSingleMonth"=>nil,
 "dateEarliestSingleDay"=>nil,
 "dateEarliestScalarValue"=>nil,
 "dateEarliestSingleEra"=>
  "urn:cspace:core.collectionspace.org:vocabularies:name(dateera):item:name(ce)'CE'",
 "dateLatestYear"=>nil,
 "dateLatestMonth"=>nil,
 "dateLatestDay"=>nil,
 "dateLatestScalarValue"=>nil,
 "dateLatestEra"=>
  "urn:cspace:core.collectionspace.org:vocabularies:name(dateera):item:name(ce)'CE'"}
```