### PR TITLE
Refactor collectionobject converter classes

### DIFF
--- a/config/initializers/collectionspace.rb
+++ b/config/initializers/collectionspace.rb
@@ -1,6 +1,12 @@
-# Require the DEFAULT module
-Dir["#{Rails.root.join('lib', 'collectionspace', 'converter', 'default')}/*.rb"].each do |lib|
-  require lib
+# frozen_string_literal: true
+
+# Require the DEFAULT and EXTENSION modules
+%w[default extension].each do |base|
+  Dir[
+    "#{Rails.root.join('lib', 'collectionspace', 'converter', base)}/*.rb"
+  ].sort.each do |lib|
+    require lib
+  end
 end
 
 # Require everything else (starting with "_*")

--- a/lib/collectionspace/converter/anthro/collectionobject.rb
+++ b/lib/collectionspace/converter/anthro/collectionobject.rb
@@ -1,67 +1,72 @@
+# frozen_string_literal: true
+
+require_relative '../core/collectionobject'
+
 module CollectionSpace
   module Converter
     module Anthro
-      class AnthroCollectionObject < CollectionObject
+      class AnthroCollectionObject < CoreCollectionObject
         ::AnthroCollectionObject = CollectionSpace::Converter::Anthro::AnthroCollectionObject
+        include CulturalCare
+        def initialize(attributes, config = {})
+          super(attributes, config)
+          @redefined = [
+            'objectproductionpeople',
+            'objectproductionpeoplerole'
+          ]
+        end
+
         def convert
-          run(wrapper: "document") do |xml|
+          run(wrapper: 'document') do |xml|
             xml.send(
-                "ns2:collectionobjects_common",
-                "xmlns:ns2" => "http://collectionspace.org/services/collectionobject",
-                "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_common',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
-              AnthroCollectionObject.map_common(xml, attributes, redefined_fields)
+              map_common(xml, attributes)
             end
 
             xml.send(
-              "ns2:collectionobjects_culturalcare",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/culturalcare",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_culturalcare',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/culturalcare',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
-              AnthroCollectionObject.map_cultural_care(xml, attributes, redefined_fields)
+              map_cultural_care(xml, attributes)
             end
 
             xml.send(
-                "ns2:collectionobjects_anthro",
-                "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/anthro",
-                "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_anthro',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/anthro',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
-              AnthroCollectionObject.map_anthro(xml, attributes)
+              map_anthro(xml, attributes)
             end
 
             xml.send(
-              "ns2:collectionobjects_annotation",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/annotation",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_annotation',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/annotation',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
-              AnthroCollectionObject.map_annotation(xml, attributes)
+              map_annotation(xml, attributes)
             end
 
             xml.send(
-              "ns2:collectionobjects_nagpra",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/nagpra",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_nagpra',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/nagpra',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
-              AnthroCollectionObject.map_nagpra(xml, attributes)
+              map_nagpra(xml, attributes)
             end
           end
         end
 
-        def redefined_fields
-          @redefined.concat([
-            'objectproductionpeople',
-            'objectproductionpeoplerole'
-          ])
-          super
-        end
-
-        def self.map_common(xml, attributes, redefined)
-          CoreCollectionObject.map_common(xml, attributes.merge(redefined))
+        def map_common(xml, attributes)
+          super(xml, attributes.merge(redefined_fields))
 
           opp_data = {
             'objectproductionpeopleethnoculture' => 'objectProductionPeople',
@@ -69,9 +74,9 @@ module CollectionSpace
             'objectproductionpeoplerole' => 'objectProductionPeopleRole'
           }
           opp_transforms = {
-            'objectproductionpeopleethnoculture' => {'authority' => ['conceptauthorities', 'ethculture']},
-            'objectproductionpeoplearchculture' =>  {'authority' => ['conceptauthorities', 'archculture']},
-            'objectproductionpeoplerole' => {'vocab' => 'prodpeoplerole'}
+            'objectproductionpeopleethnoculture' => { 'authority' => %w[conceptauthorities ethculture] },
+            'objectproductionpeoplearchculture' => { 'authority' => %w[conceptauthorities archculture] },
+            'objectproductionpeoplerole' => { 'vocab' => 'prodpeoplerole' }
           }
           CSXML.add_single_level_group_list(
             xml, attributes,
@@ -81,12 +86,7 @@ module CollectionSpace
           )
         end
 
-        # EXTENSIONS
-        def self.map_cultural_care(xml, attributes, redefined)
-          CulturalCare.map_cultural_care(xml, attributes.merge(redefined))
-        end
-        
-          def self.map_anthro(xml, attributes)
+        def map_anthro(xml, attributes)
           # -=-=-=-=--=-=-=-=-=-=-=-=-=-=-=-=-=-=
           # localityGroupList
           # -=-=-=-=--=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -98,7 +98,7 @@ module CollectionSpace
           }
 
           locality_transforms = {
-            'fieldlocplace' => { 'authority' => ['placeauthorities', 'place'] }
+            'fieldlocplace' => { 'authority' => %w[placeauthorities place] }
           }
 
           CSXML.add_single_level_group_list(
@@ -124,25 +124,22 @@ module CollectionSpace
             'mortuarytreatment' => 'mortuaryTreatment',
             'mortuarytreatmentnote' => 'mortuaryTreatmentNote'
           }
-          mortuary_treatment_fields = [
-            'mortuaryTreatment',
-            'mortuaryTreatmentNote'
+          mortuary_treatment_fields = %w[
+            mortuaryTreatment
+            mortuaryTreatmentNote
           ]
 
           commingled_transforms = {
-            'agerange' => {'replace' => [{'find' => ' - ',
-                                          'replace' => '-',
-                                          'type' => 'plain'}],
-                           'vocab' => 'agerange'
-                          },
-            'behrensmeyerupper' => {'special' => 'behrensmeyer_translate',
-                                    'vocab' => 'behrensmeyer'
-                                   },
-            'behrensmeyersinglelower' => {'special' => 'behrensmeyer_translate',
-                                          'vocab' => 'behrensmeyer'
-                                         },
-            'dentition' => {'special' => 'boolean'},
-            'mortuarytreatment' => {'vocab' => 'mortuarytreatment'}
+            'agerange' => { 'replace' => [{ 'find' => ' - ',
+                                            'replace' => '-',
+                                            'type' => 'plain' }],
+                            'vocab' => 'agerange' },
+            'behrensmeyerupper' => { 'special' => 'behrensmeyer_translate',
+                                     'vocab' => 'behrensmeyer' },
+            'behrensmeyersinglelower' => { 'special' => 'behrensmeyer_translate',
+                                           'vocab' => 'behrensmeyer' },
+            'dentition' => { 'special' => 'boolean' },
+            'mortuarytreatment' => { 'vocab' => 'mortuarytreatment' }
           }
 
           CSXML.add_nested_group_lists(
@@ -153,11 +150,11 @@ module CollectionSpace
             mortuary_treatment_fields,
             commingled_transforms,
             sublist_suffix: 'GroupList',
-            subgroup_suffix: 'Group',
+            subgroup_suffix: 'Group'
           )
         end
 
-        def self.map_annotation(xml, attributes)
+        def map_annotation(xml, attributes)
           # -=-=-=-=--=-=-=-=-=-=-=-=-=-=-=-=-=-=
           # annotationGroupList
           # -=-=-=-=--=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -169,9 +166,9 @@ module CollectionSpace
           }
 
           annotation_transforms = {
-            'annotationauthor' => {'authority' => ['personauthorities', 'person']},
-            'annotationtype' => {'vocab' => 'annotationtype'},
-            'annotationdate' => {'special' => 'unstructured_date_string'}
+            'annotationauthor' => { 'authority' => %w[personauthorities person] },
+            'annotationtype' => { 'vocab' => 'annotationtype' },
+            'annotationdate' => { 'special' => 'unstructured_date_string' }
           }
 
           CSXML.add_single_level_group_list(
@@ -181,21 +178,21 @@ module CollectionSpace
             annotation_transforms
           )
         end
-        
-        def self.map_nagpra(xml, attributes)
+
+        def map_nagpra(xml, attributes)
           pairs = {
             'nagprareportfiled' => 'nagpraReportFiled',
             'nagprareportfiledby' => 'nagpraReportFiledBy'
           }
           pair_transforms = {
-            'nagprareportfiled' => {'special' => 'boolean'},
-            'nagprareportfiledby' => {'authority' => ['personauthorities', 'person']}
+            'nagprareportfiled' => { 'special' => 'boolean' },
+            'nagprareportfiledby' => { 'authority' => %w[personauthorities person] }
           }
           CSXML::Helpers.add_pairs(xml, attributes, pairs, pair_transforms)
 
           repeats = {
-            'repatriationnote' => ['repatriationNotes', 'repatriationNote'],
-            'nagpracategory' => ['nagpraCategories', 'nagpraCategory']
+            'repatriationnote' => %w[repatriationNotes repatriationNote],
+            'nagpracategory' => %w[nagpraCategories nagpraCategory]
           }
           repeat_transforms = {
             'nagpracategory' => { 'vocab' => 'nagpracategory' }
@@ -204,8 +201,7 @@ module CollectionSpace
 
           CSXML::Helpers.add_date_group(
             xml, 'nagpraReportFiledDate', CSDTP.parse(attributes['nagprareportfileddate']), ''
-            )
-
+          )
         end
       end
     end

--- a/lib/collectionspace/converter/core/collectionobject.rb
+++ b/lib/collectionspace/converter/core/collectionobject.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require_relative '../default/record'
+
 module CollectionSpace
   module Converter
     module Core
@@ -5,11 +9,11 @@ module CollectionSpace
         ::CoreCollectionObject = CollectionSpace::Converter::Core::CoreCollectionObject
         def convert
           run do |xml|
-            CoreCollectionObject.map_common(xml, attributes)
+            map_common(xml, attributes)
           end
         end
 
-        def self.map_common(xml, attributes)
+        def map_common(xml, attributes)
           pairs = {
             'objectnumber' => 'objectNumber',
             'numberofobjects' => 'numberOfObjects',
@@ -51,86 +55,86 @@ module CollectionSpace
             'fieldcollectionnumber' => 'fieldCollectionNumber'
           }
           pairs_transforms = {
-            'agequalifier' => {'vocab' => 'agequalifier'},
-            'ownershipexchangepricecurrency' => {'vocab' => 'currency'},
-            'fieldcollectionplace' => {'authority' => ['placeauthorities', 'place']}
+            'agequalifier' => { 'vocab' => 'agequalifier' },
+            'ownershipexchangepricecurrency' => { 'vocab' => 'currency' },
+            'fieldcollectionplace' => { 'authority' => %w[placeauthorities place] }
           }
           CSXML::Helpers.add_title(xml, attributes)
           CSXML::Helpers.add_pairs(xml, attributes, pairs, pairs_transforms)
           repeats = {
-            'briefdescription' => ['briefDescriptions', 'briefDescription'],
-            'comments' => ['comments', 'comment'],
-            'fieldcollectioneventname' => ['fieldColEventNames', 'fieldColEventName'],
-            'form' => ['forms', 'form'],
-            'responsibledepartment' => ['responsibleDepartments', 'responsibleDepartment'],
-            'style' => ['styles', 'style'],
-            'color' => ['colors', 'color'],
-            'objectstatus' => ['objectStatusList', 'objectStatus'],
-            'contentperson' => ['contentPersons', 'contentPerson'],
-            'inventorystatus' => ['inventoryStatusList', 'inventoryStatus'],
-            'publishto' => ['publishToList', 'publishTo'],
-            'objectproductionreason' => ['objectProductionReasons', 'objectProductionReason'],
-            'objectproductiondate' => ['objectProductionDateGroupList', 'objectProductionDateGroup'],
-            'ownerperson' => ['owners', 'owner'],
-            'ownerorganization' => ['owners', 'owner'],
-            'contentpeople' => ['contentPeoples', 'contentPeople'],
-            'contentplace' => ['contentPlaces', 'contentPlace'],
-            'contentscript' => ['contentScripts', 'contentScript'],
-            'contentorganization' => ['contentOrganizations', 'contentOrganization'],
-            'contentlanguage' => ['contentLanguages', 'contentLanguage'],
-            'contentactivity' => ['contentActivities', 'contentActivity'],
-            'contentposition' => ['contentPositions', 'contentPosition'], 
-            'contentconceptassociated' => ['contentConcepts', 'contentConcept'],
-            'contentconceptmaterial' => ['contentConcepts', 'contentConcept'],
-            'assoceventorganization' => ['assocEventOrganizations', 'assocEventOrganization'],
-            'assoceventpeople' => ['assocEventPeoples', 'assocEventPeople'],
-            'assoceventperson' => ['assocEventPersons', 'assocEventPerson'],
-            'assoceventplace' => ['assocEventPlaces', 'assocEventPlace'],
-            'ownersreference' => ['ownersReferences', 'ownersReference'],
-            'viewersreference' => ['viewersReferences', 'viewersReference'],
-            'fieldcollectionmethod' => ['fieldCollectionMethods', 'fieldCollectionMethod'],
-            'fieldcollectionsource' => ['fieldCollectionSources', 'fieldCollectionSource'],
-            'fieldcollectorperson' => ['fieldCollectors', 'fieldCollector'],
-            'fieldcollectororganization' => ['fieldCollectors', 'fieldCollector']
+            'briefdescription' => %w[briefDescriptions briefDescription],
+            'comments' => %w[comments comment],
+            'fieldcollectioneventname' => %w[fieldColEventNames fieldColEventName],
+            'form' => %w[forms form],
+            'responsibledepartment' => %w[responsibleDepartments responsibleDepartment],
+            'style' => %w[styles style],
+            'color' => %w[colors color],
+            'objectstatus' => %w[objectStatusList objectStatus],
+            'contentperson' => %w[contentPersons contentPerson],
+            'inventorystatus' => %w[inventoryStatusList inventoryStatus],
+            'publishto' => %w[publishToList publishTo],
+            'objectproductionreason' => %w[objectProductionReasons objectProductionReason],
+            'objectproductiondate' => %w[objectProductionDateGroupList objectProductionDateGroup],
+            'ownerperson' => %w[owners owner],
+            'ownerorganization' => %w[owners owner],
+            'contentpeople' => %w[contentPeoples contentPeople],
+            'contentplace' => %w[contentPlaces contentPlace],
+            'contentscript' => %w[contentScripts contentScript],
+            'contentorganization' => %w[contentOrganizations contentOrganization],
+            'contentlanguage' => %w[contentLanguages contentLanguage],
+            'contentactivity' => %w[contentActivities contentActivity],
+            'contentposition' => %w[contentPositions contentPosition],
+            'contentconceptassociated' => %w[contentConcepts contentConcept],
+            'contentconceptmaterial' => %w[contentConcepts contentConcept],
+            'assoceventorganization' => %w[assocEventOrganizations assocEventOrganization],
+            'assoceventpeople' => %w[assocEventPeoples assocEventPeople],
+            'assoceventperson' => %w[assocEventPersons assocEventPerson],
+            'assoceventplace' => %w[assocEventPlaces assocEventPlace],
+            'ownersreference' => %w[ownersReferences ownersReference],
+            'viewersreference' => %w[viewersReferences viewersReference],
+            'fieldcollectionmethod' => %w[fieldCollectionMethods fieldCollectionMethod],
+            'fieldcollectionsource' => %w[fieldCollectionSources fieldCollectionSource],
+            'fieldcollectorperson' => %w[fieldCollectors fieldCollector],
+            'fieldcollectororganization' => %w[fieldCollectors fieldCollector]
           }
           repeatstransforms = {
-            'contentperson' => {'authority' => ['personauthorities', 'person']},
-            'inventorystatus' => {'vocab' => 'inventorystatus'},
-            'publishto' => {'vocab' => 'publishto'},
-            'objectproductiondate' => {'special' => 'structured_date'},
-            'ownerperson' => {'authority' => ['personauthorities', 'person']},
-            'ownerorganization' => {'authority' => ['orgauthorities', 'organization']},
-            'contentorganization' => {'authority' => ['orgauthorities', 'organization']},
-            'contentlanguage' => {'vocab' => 'languages'},
-            'contentconceptassociated' => {'authority' => ['conceptauthorities', 'concept']},
-            'contentconceptmaterial' => {'authority' => ['conceptauthorities', 'material_ca']},
-            'assoceventorganization' => {'authority' => ['orgauthorities', 'organization']},
-            'assoceventperson' => {'authority' => ['personauthorities', 'person']},
-            'fieldcollectionmethod' => {'vocab' => 'collectionmethod'},
-            'fieldcollectionsource' => {'authority' => ['personauthorities', 'person']},
-            'fieldcollectorperson' => {'authority' => ['personauthorities', 'person']},
-            'fieldcollectororganization' => {'authority' => ['orgauthorities', 'organization']}
+            'contentperson' => { 'authority' => %w[personauthorities person] },
+            'inventorystatus' => { 'vocab' => 'inventorystatus' },
+            'publishto' => { 'vocab' => 'publishto' },
+            'objectproductiondate' => { 'special' => 'structured_date' },
+            'ownerperson' => { 'authority' => %w[personauthorities person] },
+            'ownerorganization' => { 'authority' => %w[orgauthorities organization] },
+            'contentorganization' => { 'authority' => %w[orgauthorities organization] },
+            'contentlanguage' => { 'vocab' => 'languages' },
+            'contentconceptassociated' => { 'authority' => %w[conceptauthorities concept] },
+            'contentconceptmaterial' => { 'authority' => %w[conceptauthorities material_ca] },
+            'assoceventorganization' => { 'authority' => %w[orgauthorities organization] },
+            'assoceventperson' => { 'authority' => %w[personauthorities person] },
+            'fieldcollectionmethod' => { 'vocab' => 'collectionmethod' },
+            'fieldcollectionsource' => { 'authority' => %w[personauthorities person] },
+            'fieldcollectorperson' => { 'authority' => %w[personauthorities person] },
+            'fieldcollectororganization' => { 'authority' => %w[orgauthorities organization] }
           }
           CSXML::Helpers.add_repeats(xml, attributes, repeats, repeatstransforms)
-          #measuredPartGroupList, measuredPartGroup 
+          # measuredPartGroupList, measuredPartGroup
           CSXML::Helpers.add_measured_part_group_list(xml, attributes)
-          #objectProductionDateGroupList, objectProductionDateGroup
+          # objectProductionDateGroupList, objectProductionDateGroup
           CSXML::Helpers.add_date_group_list(
             xml, 'objectProductionDate', attributes['objectproductiondate']
           )
-          #contentDateGroup
+          # contentDateGroup
           CSXML::Helpers.add_date_group(
             xml, 'contentDate', CSDTP.parse(attributes['contentdategroup'])
           )
-          #fieldCollectionDateGroup
+          # fieldCollectionDateGroup
           CSXML::Helpers.add_date_group(
             xml, 'fieldCollectionDate', CSDTP.parse(attributes['fieldcollectiondategroup'])
           )
-          #ownershipDateGroupList, ownershipDateGroup
+          # ownershipDateGroupList, ownershipDateGroup
           CSXML::Helpers.add_date_group_list(
             xml, 'ownershipDate', attributes['ownershipdate']
           )
-          #textualInscriptionGroupList,textualInscriptionGroup 
+          # textualInscriptionGroupList,textualInscriptionGroup
           textualinscriptiondata = {
             'inscriptioncontent' => 'inscriptionContent',
             'inscriptioncontentinscriberperson' => 'inscriptionContentInscriber',
@@ -146,10 +150,10 @@ module CollectionSpace
             'inscriptioncontenttransliteration' => 'inscriptionContentTransliteration'
           }
           textualinscriptiontransforms = {
-            'inscriptioncontentinscriberperson' => {'authority' => ['personauthorities', 'person']},
-            'inscriptioncontentinscriberorganization' => {'authority' => ['orgauthorities', 'organization']},
-            'inscriptioncontentlanguage' => {'vocab' => 'languages'},
-            'inscriptioncontentdategroup' => {'special' => 'structured_date'}
+            'inscriptioncontentinscriberperson' => { 'authority' => %w[personauthorities person] },
+            'inscriptioncontentinscriberorganization' => { 'authority' => %w[orgauthorities organization] },
+            'inscriptioncontentlanguage' => { 'vocab' => 'languages' },
+            'inscriptioncontentdategroup' => { 'special' => 'structured_date' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -158,7 +162,7 @@ module CollectionSpace
             textualinscriptiondata,
             textualinscriptiontransforms
           )
-          #nonTextualInscriptionGroupList, nonTextualInscriptionGroup
+          # nonTextualInscriptionGroupList, nonTextualInscriptionGroup
           nontextualinscriptiondata = {
             'inscriptiondescriptiondategroup' => 'inscriptionDescriptionDateGroup',
             'inscriptiondescription' => 'inscriptionDescription',
@@ -170,9 +174,9 @@ module CollectionSpace
             'inscriptiondescriptiontype' => 'inscriptionDescriptionType'
           }
           nontextualinscriptiontransforms = {
-            'inscriptiondescriptioninscriberperson' => {'authority' => ['personauthorities', 'person']},
-            'inscriptiondescriptioninscriberorganization' => {'authority' => ['orgauthorities', 'organization']},
-            'inscriptiondescriptiondategroup' => {'special' => 'structured_date'}
+            'inscriptiondescriptioninscriberperson' => { 'authority' => %w[personauthorities person] },
+            'inscriptiondescriptioninscriberorganization' => { 'authority' => %w[orgauthorities organization] },
+            'inscriptiondescriptiondategroup' => { 'special' => 'structured_date' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -181,13 +185,13 @@ module CollectionSpace
             nontextualinscriptiondata,
             nontextualinscriptiontransforms
           )
-          #objectProductionOrganizationGroupList, objectProductionOrganizationGroup
+          # objectProductionOrganizationGroupList, objectProductionOrganizationGroup
           objectprodorgdata = {
             'objectproductionorganization' => 'objectProductionOrganization',
             'objectproductionorganizationrole' => 'objectProductionOrganizationRole'
           }
           objectprodorgtransforms = {
-            'objectproductionorganization' => {'authority' => ['orgauthorities', 'organization']}
+            'objectproductionorganization' => { 'authority' => %w[orgauthorities organization] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -196,13 +200,13 @@ module CollectionSpace
             objectprodorgdata,
             objectprodorgtransforms
           )
-          #objectProductionPersonGroupList, objectProductionPersonGroup
+          # objectProductionPersonGroupList, objectProductionPersonGroup
           objectprodpersondata = {
             'objectproductionperson' => 'objectProductionPerson',
             'objectproductionpersonrole' => 'objectProductionPersonRole'
           }
           objectprodpersontransforms = {
-            'objectproductionperson' => {'authority' => ['personauthorities', 'person']}
+            'objectproductionperson' => { 'authority' => %w[personauthorities person] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -215,14 +219,14 @@ module CollectionSpace
           objectprodpeopledata = {
             'objectproductionpeople' => 'objectProductionPeople',
             'objectproductionpeoplerole' => 'objectProductionPeopleRole'
-          } 
+          }
           CSXML.add_single_level_group_list(
             xml,
             attributes,
             'objectProductionPeople',
-            objectprodpeopledata,
+            objectprodpeopledata
           )
-          #objectNameList, objectNameGroup
+          # objectNameList, objectNameGroup
           objectname_data = {
             'objectname' => 'objectName',
             'objectnamecurrency' => 'objectNameCurrency',
@@ -230,10 +234,10 @@ module CollectionSpace
             'objectnamesystem' => 'objectNameSystem',
             'objectnametype' => 'objectNameType',
             'objectnamelanguage' => 'objectNameLanguage',
-            'objectnamenote' => 'objectNameNote',
+            'objectnamenote' => 'objectNameNote'
           }
           objectname_transforms = {
-            'objectnamelanguage' => {'vocab' => 'languages'}
+            'objectnamelanguage' => { 'vocab' => 'languages' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -243,7 +247,7 @@ module CollectionSpace
             objectname_transforms,
             list_suffix: 'List'
           )
-          #otherNumberList, otherNumber
+          # otherNumberList, otherNumber
           othernumber_data = {
             'numbervalue' => 'numberValue',
             'numbertype' => 'numberType'
@@ -256,7 +260,7 @@ module CollectionSpace
             list_suffix: 'List',
             group_suffix: ''
           )
-          #objectComponentGroupList, objectComponentGroup
+          # objectComponentGroupList, objectComponentGroup
           objectcompdata = {
             'objectcomponentname' => 'objectComponentName',
             'objectcomponentinformation' => 'objectComponentInformation'
@@ -265,9 +269,9 @@ module CollectionSpace
             xml,
             attributes,
             'objectComponent',
-            objectcompdata,
+            objectcompdata
           )
-          #materialGroupList, materialGroup
+          # materialGroupList, materialGroup
           materialdata = {
             'materialname' => 'materialName',
             'material' => 'material',
@@ -281,7 +285,7 @@ module CollectionSpace
             'material',
             materialdata
           )
-          #technicalAttributeGroupList, technicalAttributeGroup
+          # technicalAttributeGroupList, technicalAttributeGroup
           techattribute_data = {
             'technicalattribute' => 'technicalAttribute',
             'technicalattributemeasurementunit' => 'technicalAttributeMeasurementUnit',
@@ -293,7 +297,7 @@ module CollectionSpace
             'technicalAttribute',
             techattribute_data
           )
-          #techniqueGroupList, techniqueGroup
+          # techniqueGroupList, techniqueGroup
           technique_data = {
             'technique' => 'technique',
             'techniquetype' => 'techniqueType'
@@ -304,7 +308,7 @@ module CollectionSpace
             'technique',
             technique_data
           )
-          #objectProductionPlaceGroupList, objectProductionPlaceGroup
+          # objectProductionPlaceGroupList, objectProductionPlaceGroup
           prodplace_data = {
             'objectproductionplace' => 'objectProductionPlace',
             'objectproductionplacerole' => 'objectProductionPlaceRole'
@@ -315,7 +319,7 @@ module CollectionSpace
             'objectProductionPlace',
             prodplace_data
           )
-          #usageGroupList, usageGroup
+          # usageGroupList, usageGroup
           usage_data = {
             'usage' => 'usage',
             'usagenote' => 'usageNote'
@@ -326,7 +330,7 @@ module CollectionSpace
             'usage',
             usage_data
           )
-          #contentEventNameGroupList, contentEventNameGroup
+          # contentEventNameGroupList, contentEventNameGroup
           contenteventname_data = {
             'contenteventname' => 'contentEventName',
             'contenteventnametype' => 'contentEventNameType'
@@ -337,7 +341,7 @@ module CollectionSpace
             'contentEventName',
             contenteventname_data
           )
-          #contentOtherGroupList, contentOtherGroup
+          # contentOtherGroupList, contentOtherGroup
           contentother_data = {
             'contentother' => 'contentOther',
             'contentothertype' => 'contentOtherType'
@@ -348,7 +352,7 @@ module CollectionSpace
             'contentOther',
             contentother_data
           )
-          #contentObjectGroupList, contentObjectGroup
+          # contentObjectGroupList, contentObjectGroup
           contentobject_data = {
             'contentobject' => 'contentObject',
             'contentobjecttype' => 'contentObjectType'
@@ -359,7 +363,7 @@ module CollectionSpace
             'contentObject',
             contentobject_data
           )
-          #assocActivityGroupList, assocActivityGroup
+          # assocActivityGroupList, assocActivityGroup
           assocactivity_data = {
             'assocactivity' => 'assocActivity',
             'assocactivitytype' => 'assocActivityType',
@@ -371,7 +375,7 @@ module CollectionSpace
             'assocActivity',
             assocactivity_data
           )
-          #assocObjectGroupList, assocObjectGroup
+          # assocObjectGroupList, assocObjectGroup
           assocobject_data = {
             'assocobject' => 'assocObject',
             'assocobjectnote' => 'assocObjectNote',
@@ -383,14 +387,14 @@ module CollectionSpace
             'assocObject',
             assocobject_data
           )
-          #assocConceptGroupList, assocConceptGroup
+          # assocConceptGroupList, assocConceptGroup
           assocconcept_data = {
             'assocconcept' => 'assocConcept',
             'assocconceptnote' => 'assocConceptNote',
             'assocconcepttype' => 'assocConceptType'
           }
           assocconcept_transforms = {
-            'assocconcept' => {'authority' => ['conceptauthorities', 'concept']} 
+            'assocconcept' => { 'authority' => %w[conceptauthorities concept] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -399,7 +403,7 @@ module CollectionSpace
             assocconcept_data,
             assocconcept_transforms
           )
-          #assocCulturalContextGroupList, assocCulturalContextGroup
+          # assocCulturalContextGroupList, assocCulturalContextGroup
           assocculturalcontext_data = {
             'assocculturalcontext' => 'assocCulturalContext',
             'assocculturalcontextnote' => 'assocCulturalContextNote',
@@ -411,14 +415,14 @@ module CollectionSpace
             'assocCulturalContext',
             assocculturalcontext_data
           )
-          #assocOrganizationGroupList, assocOrganizationGroup
+          # assocOrganizationGroupList, assocOrganizationGroup
           assocorganization_data = {
             'assocorganization' => 'assocOrganization',
             'assocorganizationtype' => 'assocOrganizationType',
             'assocorganizationnote' => 'assocOrganizationNote'
           }
           assocorganization_transforms = {
-            'assocorganization' => {'authority' => ['orgauthorities', 'organization']}
+            'assocorganization' => { 'authority' => %w[orgauthorities organization] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -427,7 +431,7 @@ module CollectionSpace
             assocorganization_data,
             assocorganization_transforms
           )
-          #assocPeopleGroupList, assocPeopleGroup
+          # assocPeopleGroupList, assocPeopleGroup
           assocpeople_data = {
             'assocpeople' => 'assocPeople',
             'assocpeoplenote' => 'assocPeopleNote',
@@ -439,14 +443,14 @@ module CollectionSpace
             'assocPeople',
             assocpeople_data
           )
-          #assocPersonGroupList, assocPersonGroup
+          # assocPersonGroupList, assocPersonGroup
           assocperson_data = {
             'assocperson' => 'assocPerson',
             'assocpersontype' => 'assocPersonType',
             'assocpersonnote' => 'assocPersonNote'
           }
           assocperson_transforms = {
-            'assocperson' => {'authority' => ['personauthorities', 'person']}
+            'assocperson' => { 'authority' => %w[personauthorities person] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -455,7 +459,7 @@ module CollectionSpace
             assocperson_data,
             assocperson_transforms
           )
-          #assocPlaceGroupList, assocPlaceGroup
+          # assocPlaceGroupList, assocPlaceGroup
           assocplace_data = {
             'assocplace' => 'assocPlace',
             'assocplacenote' => 'assocPlaceNote',
@@ -467,14 +471,14 @@ module CollectionSpace
             'assocPlace',
             assocplace_data
           )
-          #assocDateGroupList, assocDateGroup
+          # assocDateGroupList, assocDateGroup
           assocdate_data = {
             'assocdatenote' => 'assocDateNote',
             'assocdatetype' => 'assocDateType',
             'assocstructureddategroup' => 'assocStructuredDateGroup'
           }
           assocdate_transforms = {
-            'assocstructureddategroup' => {'special' => 'structured_date'}
+            'assocstructureddategroup' => { 'special' => 'structured_date' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -483,13 +487,13 @@ module CollectionSpace
             assocdate_data,
             assocdate_transforms
           )
-          #referenceGroupList, referenceGroup
+          # referenceGroupList, referenceGroup
           referencegroup_data = {
             'reference' => 'reference',
-            'referencenote' => 'referenceNote',
+            'referencenote' => 'referenceNote'
           }
           referencegroup_transforms = {
-            'reference' => {'authority' => ['citationauthorities', 'citation']}
+            'reference' => { 'authority' => %w[citationauthorities citation] }
           }
           CSXML.add_single_level_group_list(
             xml,

--- a/lib/collectionspace/converter/extension/cultural_care.rb
+++ b/lib/collectionspace/converter/extension/cultural_care.rb
@@ -6,7 +6,7 @@ module CollectionSpace
       # Cultural Care Extension
       module CulturalCare
         ::CulturalCare = CollectionSpace::Converter::Extension::CulturalCare
-        def self.map_cultural_care(xml, attributes)
+        def map_cultural_care(xml, attributes)
           repeats = {
             'culturalcarenote' => %w[culturalCareNotes culturalCareNote]
           }

--- a/lib/collectionspace/converter/lhmc/collectionobject.rb
+++ b/lib/collectionspace/converter/lhmc/collectionobject.rb
@@ -1,40 +1,43 @@
+# frozen_string_literal: true
+
+require_relative '../core/collectionobject'
+
 module CollectionSpace
   module Converter
     module Lhmc
-      class LhmcCollectionObject < CollectionObject
+      class LhmcCollectionObject < CoreCollectionObject
         ::LhmcCollectionObject = CollectionSpace::Converter::Lhmc::LhmcCollectionObject
+        include CulturalCare
+        def initialize(attributes, config = {})
+          super(attributes, config)
+          # List all fields that will be overridden or removed here.
 
+          # IMPORTANT: If the field to be overridden is part of a grouping of fields (repeats or group list),
+          #   you need to list ALL the fields that are part of the group, and completely redefine the group
+          #   here. Otherwise, you will get the value of each field not listed twice.
 
-        # List all fields that will be overridden or removed here.
+          # Listing a field here, but not redefining it will remove it from the new module.
 
-        # IMPORTANT: If the field to be overridden is part of a grouping of fields (repeats or group list),
-        #   you need to list ALL the fields that are part of the group, and completely redefine the group
-        #   here. Otherwise, you will get the value of each field not listed twice.
+          # @redefined is an Array of fieldname values. We add fields to it.
 
-        # Listing a field here, but not redefining it will remove it from the new module.
+          # To use call the redefined_fields method definition from Default::Record, which
+          #   returns a Hash where each key is an element of @redefined and all values are nil
 
-        # @redefined is an Array of fieldname values. We add fields to it.
-
-        # Then super calls the redefined_fields method definition from Default::Record, which
-        #   returns a Hash where each key is an element of @redefined and all values are nil
-
-        # Later, we call the CoreCollectionObject and CulturalCare's .map_* methods.
-        #  Instead of sending the actual attributes from the CSV in those calls, we merge this
-        #  redefined_fields hash in with the real attributes hash, which replaces any existing data
-        #  in the listed fields with nil. 
-        def redefined_fields
-          @redefined.concat([
-            'numbertype',
-            'numbervalue',
-            'contentplace',
-            'inscriptioncontenttype',
-            'inscriptioncontentmethod',
-            'objectproductionplace',
-            'assocplace',
-            'ownershipplace',
-            'contentscript'
-          ])
-          super
+          # Later, we call the CoreCollectionObject and CulturalCare's .map_* methods.
+          #  Instead of sending the actual attributes from the CSV in those calls, we merge this
+          #  redefined_fields hash in with the real attributes hash, which replaces any existing data
+          #  in the listed fields with nil.
+          @redefined = %w[
+            numbertype
+            numbervalue
+            contentplace
+            inscriptioncontenttype
+            inscriptioncontentmethod
+            objectproductionplace
+            assocplace
+            ownershipplace
+            contentscript
+          ]
         end
 
         # convert is used to build the XML document, including the elements which group fields from
@@ -50,54 +53,41 @@ module CollectionSpace
         # NOTE:
         # The namespace for the core module is "common" because the "core" namespace is used for fields
         #  used across the CSpace application (like record created and updated timestamps). So, that's
-        #  confusing... 
+        #  confusing...
         def convert
-          run(wrapper: "document") do |xml|
+          run(wrapper: 'document') do |xml|
             # The xml.send wraps all fields in the <collectionobjects_common> element and defines
             #  the namespace attributes
             xml.send(
-                "ns2:collectionobjects_common",
-                "xmlns:ns2" => "http://collectionspace.org/services/collectionobject",
-                "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_common',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
               # NOTE that we are calling the map_common method of LhmcCollectionObject!
-              #  This calls CoreCollectionObject.map_common (with overridden fields removed)
+              #  This calls CoreCollectionObject map_common (with overridden fields removed)
               #  to populate all non-overridden fields AND defines the logic for any overridden fields
-              LhmcCollectionObject.map_common(xml, attributes, redefined_fields)
+              map_common(xml, attributes)
             end
 
             xml.send(
-              "ns2:collectionobjects_culturalcare",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/culturalcare",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_culturalcare',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/culturalcare',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
               # Follows the same pattern as above. Note that we are not overriding any culturalcare
               #  fields at this time, but we follow the same pattern a) for consistency; and
               #  b) to make it easy to ever override a culturalcare field
-              LhmcCollectionObject.map_cultural_care(xml, attributes, redefined_fields)
+              map_cultural_care(xml, attributes)
             end
-
-            xml.send(
-                "ns2:collectionobjects_lhmc",
-                "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/lhmc",
-                "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
-            ) do
-              xml.parent.namespace = nil
-              # The map_lhmc method defines conversion logic for fields defined in the lhmc data
-              #   profile
-              # This logic cannot override itself, so we don't send the redefined_fields!
-              LhmcCollectionObject.map_lhmc(xml, attributes)
-            end
-
           end
         end
 
         # CORE
-        def self.map_common(xml, attributes, redefined)
+        def map_common(xml, attributes)
           # map non-overridden fields according to core logic
-          CoreCollectionObject.map_common(xml, attributes.merge(redefined))
+          super(xml, attributes.merge(redefined_fields))
 
           # OVERRIDES
           pairs = {
@@ -105,28 +95,28 @@ module CollectionSpace
             'ownershipplacetgn' => 'ownershipPlace'
           }
           pairs_transforms = {
-            'ownershipplacelocal' => {'authority' => ['placeauthorities', 'place']},
-            'ownershipplacetgn' => {'authority' => ['placeauthorities', 'tgn_place']}
+            'ownershipplacelocal' => { 'authority' => %w[placeauthorities place] },
+            'ownershipplacetgn' => { 'authority' => %w[placeauthorities tgn_place] }
           }
           CSXML::Helpers.add_pairs(xml, attributes, pairs, pairs_transforms)
-          
+
           repeats = {
-            'contentplacelocal' => ['contentPlaces', 'contentPlace'],
-            'contentplacetgn' => ['contentPlaces', 'contentPlace']
+            'contentplacelocal' => %w[contentPlaces contentPlace],
+            'contentplacetgn' => %w[contentPlaces contentPlace]
           }
           repeats_transforms = {
-            'contentplacelocal' => {'authority' => ['placeauthorities', 'place']},
-            'contentplacetgn' => {'authority' => ['placeauthorities', 'tgn_place']}
+            'contentplacelocal' => { 'authority' => %w[placeauthorities place] },
+            'contentplacetgn' => { 'authority' => %w[placeauthorities tgn_place] }
           }
           CSXML::Helpers.add_repeats(xml, attributes, repeats, repeats_transforms)
-          
-          #otherNumberList, otherNumber
+
+          # otherNumberList, otherNumber
           othernumber_data = {
             'numbervalue' => 'numberValue',
             'numbertype' => 'numberType'
           }
           othernumber_transforms = {
-            'numbertype' => {'vocab' => 'numbertype'}
+            'numbertype' => { 'vocab' => 'numbertype' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -144,8 +134,8 @@ module CollectionSpace
             'objectproductionrole' => 'objectProductionRole'
           }
           opp_transforms = {
-            'objectproductionplacelocal' => {'authority' => ['placeauthorities', 'place']},
-            'objectproductionplacetgn' => {'authority' => ['placeauthorities', 'tgn_place']},
+            'objectproductionplacelocal' => { 'authority' => %w[placeauthorities place] },
+            'objectproductionplacetgn' => { 'authority' => %w[placeauthorities tgn_place] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -157,36 +147,26 @@ module CollectionSpace
             group_suffix: 'Group'
           )
 
-        assoc_data = {
-          'assocplacelocal' => 'assocPlace',
-          'assocplacetgn' => 'assocPlace',
-          'assocrole' => 'assocRole'
-        }
-        assoc_transforms = {
-          'assocplacelocal' => {'authority' => ['placeauthorities', 'place']},
-          'assocplacetgn' => {'authority' => ['placeauthorities', 'tgn_place']},
-        }
-        CSXML.add_single_level_group_list(
-          xml,
-          attributes,
-          'assocPlace',
-          assoc_data,
-          assoc_transforms,
-          list_suffix: 'GroupList',
-          group_suffix: 'Group'
-        )
+          assoc_data = {
+            'assocplacelocal' => 'assocPlace',
+            'assocplacetgn' => 'assocPlace',
+            'assocrole' => 'assocRole'
+          }
+          assoc_transforms = {
+            'assocplacelocal' => { 'authority' => %w[placeauthorities place] },
+            'assocplacetgn' => { 'authority' => %w[placeauthorities tgn_place] }
+          }
+          CSXML.add_single_level_group_list(
+            xml,
+            attributes,
+            'assocPlace',
+            assoc_data,
+            assoc_transforms,
+            list_suffix: 'GroupList',
+            group_suffix: 'Group'
+          )
         end
-        # PROFILE
-        def self.map_lhmc(xml, attributes)
-          # no fields are added except for those from cultural care extension
-        end
-
-        # EXTENSIONS
-        def self.map_cultural_care(xml, attributes, redefined)
-          CulturalCare.map_cultural_care(xml, attributes.merge(redefined))
-        end
-
-      end #class LhmcCollectionObject
-    end #module Lhmc
-  end #module Converter
-end #module CollectionSpace
+      end # class LhmcCollectionObject
+    end # module Lhmc
+  end # module Converter
+end # module CollectionSpace

--- a/lib/collectionspace/converter/materials/collectionobject.rb
+++ b/lib/collectionspace/converter/materials/collectionobject.rb
@@ -1,42 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../core/collectionobject'
+
 module CollectionSpace
   module Converter
     module Materials
-      class MaterialsCollectionObject < CollectionObject
+      class MaterialsCollectionObject < CoreCollectionObject
         ::MaterialsCollectionObject = CollectionSpace::Converter::Materials::MaterialsCollectionObject
         def convert
-          run(wrapper: "document") do |xml|
+          run(wrapper: 'document') do |xml|
             xml.send(
-                "ns2:collectionobjects_common",
-                "xmlns:ns2" => "http://collectionspace.org/services/collectionobject",
-                "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_common',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
-              CoreCollectionObject.map_common(xml, attributes.merge(redefined_fields))
+              map_common(xml, attributes) # same as core
             end
 
             xml.send(
-                "ns2:collectionobjects_materials",
-                "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/local/materials",
-                "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_materials',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/local/materials',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               xml.parent.namespace = nil
-              MaterialsCollectionObject.map(xml, attributes)
+              map_materials(xml, attributes)
             end
           end
         end
 
-        def redefined_fields
-          @redefined.concat(['redefinedfield'])
-          super
-        end
-
-        def self.map(xml, attributes)
+        def map_materials(xml, attributes)
           repeats = {
-              'materialgenericcolor' => ['materialGenericColors', 'materialGenericColor'],
-              'materialphysicaldescription' => ['materialPhysicalDescriptions', 'materialPhysicalDescription']
-            }
+            'materialgenericcolor' => %w[materialGenericColors materialGenericColor],
+            'materialphysicaldescription' => %w[materialPhysicalDescriptions materialPhysicalDescription]
+          }
           repeatstransforms = {
-            'materialgenericcolor' => {'vocab' => 'materialgenericcolor'},
+            'materialgenericcolor' => { 'vocab' => 'materialgenericcolor' }
           }
           CSXML::Helpers.add_repeats(xml, attributes, repeats, repeatstransforms)
           materialconditiondata = {
@@ -44,7 +43,7 @@ module CollectionSpace
             'condition' => 'condition'
           }
           materialconditiontransforms = {
-            'condition' => {'vocab' => 'materialcondition'}
+            'condition' => { 'vocab' => 'materialcondition' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -58,7 +57,7 @@ module CollectionSpace
             'container' => 'container'
           }
           materialcontainertransforms = {
-            'container' => {'vocab' => 'materialcontainer'}
+            'container' => { 'vocab' => 'materialcontainer' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -72,7 +71,7 @@ module CollectionSpace
             'handlingnote' => 'handlingNote'
           }
           materialhandlingtransforms = {
-            'handling' => {'vocab' => 'materialhandling'}
+            'handling' => { 'vocab' => 'materialhandling' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -86,15 +85,15 @@ module CollectionSpace
             'finish' => 'finish'
           }
           materialfinishtransforms = {
-            'finish' => {'vocab' => 'materialfinish'}
-          } 
+            'finish' => { 'vocab' => 'materialfinish' }
+          }
           CSXML.add_single_level_group_list(
             xml,
             attributes,
             'materialFinish',
             materialfinishdata,
             materialfinishtransforms
-          )    
+          )
         end
       end
     end

--- a/lib/collectionspace/converter/materials/media.rb
+++ b/lib/collectionspace/converter/materials/media.rb
@@ -60,8 +60,8 @@ module CollectionSpace
             "dimensionNote" => attributes["dimension_note"],
           }
           dimensions = []
-          dims = split_mvf attributes, 'dimension'
-          values = split_mvf attributes, 'value'
+          dims = CSXML.split_mvf attributes, 'dimension'
+          values = CSXML.split_mvf attributes, 'value'
           unit = attributes["unit"]
           dims.each_with_index do |dim, index|
             dimensions << { "dimension" => dim, "value" => values[index], "measurementUnit" => unit }

--- a/lib/collectionspace/converter/ohc/collectionobject.rb
+++ b/lib/collectionspace/converter/ohc/collectionobject.rb
@@ -1,59 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../anthro/collectionobject'
+
 module CollectionSpace
   module Converter
     module OHC
       class OHCCollectionObject < AnthroCollectionObject
         ::OHCCollectionObject = CollectionSpace::Converter::OHC::OHCCollectionObject
-        def convert
-          run(wrapper: 'document') do |xml|
-            xml.send(
-              "ns2:collectionobjects_common",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
-            ) do
-              xml.parent.namespace = nil
-              OHCCollectionObject.map_common(xml, attributes, redefined_fields)
-            end
-
-            xml.send(
-              "ns2:collectionobjects_anthro",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/anthro",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
-            ) do
-              xml.parent.namespace = nil
-              OHCCollectionObject.map_anthro(xml, attributes)
-            end
-
-            xml.send(
-              "ns2:collectionobjects_annotation",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/annotation",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
-            ) do
-              xml.parent.namespace = nil
-              OHCCollectionObject.map_annotation(xml, attributes)
-            end
-
-            xml.send(
-              "ns2:collectionobjects_nagpra",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/nagpra",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
-            ) do
-              xml.parent.namespace = nil
-              OHCCollectionObject.map_nagpra(xml, attributes)
-            end
-
-            xml.send(
-              "ns2:collectionobjects_ohc",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/domain/ohc",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
-            ) do
-              xml.parent.namespace = nil
-              OHCCollectionObject.map_ohc(xml, attributes)
-            end
-          end
-        end #def convert
-
-        def redefined_fields
-          @redefined.concat([
+        def initialize(attributes, config = {})
+          super(attributes, config)
+          @redefined = [
             # by ohc
             'assocpeople',
             'assocpeopletype',
@@ -64,13 +20,61 @@ module CollectionSpace
             'objectnamecurrency',
             'objectnamenote',
             'objectnamelevel',
-            'objectnamelanguage',
-          ])
-          super
+            'objectnamelanguage'
+          ]
         end
 
-        def self.map_common(xml, attributes, redefined)
-          AnthroCollectionObject.map_common(xml, attributes, redefined)
+        def convert
+          run(wrapper: 'document') do |xml|
+            xml.send(
+              'ns2:collectionobjects_common',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
+            ) do
+              xml.parent.namespace = nil
+              map_common(xml, attributes)
+            end
+
+            xml.send(
+              'ns2:collectionobjects_anthro',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/anthro',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
+            ) do
+              xml.parent.namespace = nil
+              map_anthro(xml, attributes)
+            end
+
+            xml.send(
+              'ns2:collectionobjects_annotation',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/annotation',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
+            ) do
+              xml.parent.namespace = nil
+              map_annotation(xml, attributes)
+            end
+
+            xml.send(
+              'ns2:collectionobjects_nagpra',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/nagpra',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
+            ) do
+              xml.parent.namespace = nil
+              map_nagpra(xml, attributes)
+            end
+
+            xml.send(
+              'ns2:collectionobjects_ohc',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/domain/ohc',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
+            ) do
+              xml.parent.namespace = nil
+              map_ohc(xml, attributes)
+            end
+          end
+        end # def convert
+
+        def map_common(xml, attributes)
+          super(xml, attributes.merge(redefined_fields))
 
           # assocPeopleGroupList , assocPeopleGroup
           assocpeopledata = {
@@ -79,7 +83,7 @@ module CollectionSpace
             'assocpeoplenote' => 'assocPeopleNote'
           }
           aptransform = {
-            'assocpeople' => {'authority' => ['conceptauthorities', 'ethculture']}
+            'assocpeople' => { 'authority' => %w[conceptauthorities ethculture] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -100,8 +104,8 @@ module CollectionSpace
             'objectnamelanguage' => 'objectNameLanguage'
           }
           obj_name_transforms = {
-            'objectnamelanguage' => {'vocab' => 'languages'},
-            'objectname' => {'authority' => ['conceptauthorities', 'nomenclature']}
+            'objectnamelanguage' => { 'vocab' => 'languages' },
+            'objectname' => { 'authority' => %w[conceptauthorities nomenclature] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -113,43 +117,30 @@ module CollectionSpace
           )
         end
 
-        # EXTENTIONS
-        def self.map_annotation(xml, attributes)
-          AnthroCollectionObject.map_annotation(xml, attributes)
-        end
-
-        def self.map_anthro(xml, attributes)
-          AnthroCollectionObject.map_anthro(xml, attributes)
-        end
-
-        def self.map_nagpra(xml, attributes)
-          AnthroCollectionObject.map_nagpra(xml, attributes)
-        end
-
-        def self.map_ohc(xml, attributes)
+        def map_ohc(xml, attributes)
           pairs = {
             'descriptionlevel' => 'descriptionLevel'
           }
           pair_transforms = {
-            'descriptionlevel' => {'vocab' => 'descriptionlevel'}
+            'descriptionlevel' => { 'vocab' => 'descriptionlevel' }
           }
           CSXML::Helpers.add_pairs(xml, attributes, pairs, pair_transforms)
 
           repeats = {
-            'namedtimeperiod' => ['namedTimePeriods', 'namedTimePeriod']
+            'namedtimeperiod' => %w[namedTimePeriods namedTimePeriod]
           }
           repeat_transforms = {
-            'namedtimeperiod' => {'vocab' => 'namedtimeperiods'}
+            'namedtimeperiod' => { 'vocab' => 'namedtimeperiods' }
           }
           CSXML::Helpers.add_repeats(xml, attributes, repeats, repeat_transforms)
 
-          #oaiSiteGroupList, oaiSiteGroup
+          # oaiSiteGroupList, oaiSiteGroup
           oai_data = {
             'oaicollectionplace' => 'oaiCollectionPlace',
             'oailocverbatim' => 'oaiLocVerbatim'
           }
           oai_transforms = {
-            'oaicollectionplace' => {'authority' => ['placeauthorities', 'place']}
+            'oaicollectionplace' => { 'authority' => %w[placeauthorities place] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -157,10 +148,9 @@ module CollectionSpace
             'oaiSite',
             oai_data,
             oai_transforms
-            )
+          )
         end
-        
-      end #class OHCCollectionObject
-    end #module OHC
-  end #module Converter
-end #module CollectionSpace
+      end # class OHCCollectionObject
+    end # module OHC
+  end # module Converter
+end # module CollectionSpace

--- a/lib/collectionspace/converter/publicart/collectionobject.rb
+++ b/lib/collectionspace/converter/publicart/collectionobject.rb
@@ -1,10 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../core/collectionobject'
+
 module CollectionSpace
   module Converter
     module PublicArt
-      class PublicArtCollectionObject < CollectionObject
+      class PublicArtCollectionObject < CoreCollectionObject
         ::PublicArtCollectionObject = CollectionSpace::Converter::PublicArt::PublicArtCollectionObject
-        def redefined_fields
-          @redefined.concat([
+        def initialize(attributes, config = {})
+          super(attributes, config)
+          @redefined = [
             # not in publicart
             'objectcomponentname',
             'objectcomponentinformation',
@@ -101,80 +106,80 @@ module CollectionSpace
             'objectproductionperson',
             'objectproductionorganization',
             'owner'
-          ])
-          super
-        end      
+          ]
+        end
 
         def convert
-          run(wrapper: "document") do |xml|
+          run(wrapper: 'document') do |xml|
             xml.send(
-                "ns2:collectionobjects_common",
-                "xmlns:ns2" => "http://collectionspace.org/services/collectionobject",
-                "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_common',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               # applying namespace breaks import
               xml.parent.namespace = nil
-              PublicArtCollectionObject.map_common(xml, attributes, redefined_fields)
+              map_common(xml, attributes)
             end
 
             #
             # Public Art extension fields
             #
             xml.send(
-              "ns2:collectionobjects_publicart",
-              "xmlns:ns2" => "http://collectionspace.org/services/collectionobject/local/publicart",
-              "xmlns:xsi" => "http://www.w3.org/2001/XMLSchema-instance"
+              'ns2:collectionobjects_publicart',
+              'xmlns:ns2' => 'http://collectionspace.org/services/collectionobject/local/publicart',
+              'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance'
             ) do
               # applying namespace breaks import
               xml.parent.namespace = nil
-              PublicArtCollectionObject.map_publicart(xml, attributes)
+              map_publicart(xml, attributes)
             end
-          end #run(wrapper: "document") do |xml|
-        end #def convert
+          end # run(wrapper: "document") do |xml|
+        end # def convert
 
-        def self.map_common(xml, attributes, redefined)
-          CoreCollectionObject.map_common(xml, attributes.merge(redefined))
+        def map_common(xml, attributes)
+          super(xml, attributes.merge(redefined_fields))
+
           pairs = {
-            'computedcurrentlocation' => 'computedCurrentLocation',
+            'computedcurrentlocation' => 'computedCurrentLocation'
           }
           pairs_transforms = {
-            'computedcurrentlocation' => {'authority' => ['locationauthorities', 'indeterminate']}
+            'computedcurrentlocation' => { 'authority' => %w[locationauthorities indeterminate] }
           }
           CSXML::Helpers.add_pairs(xml, attributes, pairs, pairs_transforms)
           repeats = {
-            'responsibledepartment' => ['responsibleDepartments', 'responsibleDepartment'],
-            'contentconcept' => ['contentConcepts', 'contentConcept'],
-            'contentpersonlocal' => ['contentPersons', 'contentPerson'],
-            'contentpersonshared' => ['contentPersons', 'contentPerson'],
-            'contentorganizationlocal' => ['contentOrganizations', 'contentOrganization'],
-            'contentorganizationshared' => ['contentOrganizations', 'contentOrganization'],
-            'ownerpersonlocal' => ['owners', 'owner'],
-            'ownerpersonshared' => ['owners', 'owner'],
-            'ownerorganizationlocal' => ['owners', 'owner'],
-            'ownerorganizationshared' => ['owners', 'owner'],
-            
+            'responsibledepartment' => %w[responsibleDepartments responsibleDepartment],
+            'contentconcept' => %w[contentConcepts contentConcept],
+            'contentpersonlocal' => %w[contentPersons contentPerson],
+            'contentpersonshared' => %w[contentPersons contentPerson],
+            'contentorganizationlocal' => %w[contentOrganizations contentOrganization],
+            'contentorganizationshared' => %w[contentOrganizations contentOrganization],
+            'ownerpersonlocal' => %w[owners owner],
+            'ownerpersonshared' => %w[owners owner],
+            'ownerorganizationlocal' => %w[owners owner],
+            'ownerorganizationshared' => %w[owners owner]
+
           }
           repeat_transforms = {
-            'responsibledepartment' => {'vocab' => 'program'},
-            'contentconcept' => {'authority' => ['conceptauthorities', 'material']},
-            'contentpersonlocal' => {'authority' => ['personauthorities', 'person']},
-            'contentpersonshared' => {'authority' => ['personauthorities', 'person_shared']},
-            'contentorganizationlocal' => {'authority' => ['orgauthorities', 'organization']},
-            'contentorganizationshared' => {'authority' => ['orgauthorities', 'organization_shared']},
-            'ownerpersonlocal' => {'authority' => ['personauthorities', 'person']},
-            'ownerpersonshared' => {'authority' => ['personauthorities', 'person_shared']},
-            'ownerorganizationlocal' => {'authority' => ['orgauthorities', 'organization']},
-            'ownerorganizationshared' => {'authority' => ['orgauthorities', 'organization_shared']},
+            'responsibledepartment' => { 'vocab' => 'program' },
+            'contentconcept' => { 'authority' => %w[conceptauthorities material] },
+            'contentpersonlocal' => { 'authority' => %w[personauthorities person] },
+            'contentpersonshared' => { 'authority' => %w[personauthorities person_shared] },
+            'contentorganizationlocal' => { 'authority' => %w[orgauthorities organization] },
+            'contentorganizationshared' => { 'authority' => %w[orgauthorities organization_shared] },
+            'ownerpersonlocal' => { 'authority' => %w[personauthorities person] },
+            'ownerpersonshared' => { 'authority' => %w[personauthorities person_shared] },
+            'ownerorganizationlocal' => { 'authority' => %w[orgauthorities organization] },
+            'ownerorganizationshared' => { 'authority' => %w[orgauthorities organization_shared] }
 
           }
           CSXML::Helpers.add_repeats(xml, attributes, repeats, repeat_transforms)
-          #objectNameGroupList, objectNameGroup
+          # objectNameGroupList, objectNameGroup
           oname_data = {
             'objectname' => 'objectName',
             'objectnamenote' => 'objectNameNote'
           }
           oname_transforms = {
-            'objectname' => {'authority' => ['conceptauthorities', 'worktype']}
+            'objectname' => { 'authority' => %w[conceptauthorities worktype] }
           }
           CSXML.add_single_level_group_list(
             xml, attributes,
@@ -183,13 +188,13 @@ module CollectionSpace
             oname_transforms,
             list_suffix: 'List'
           )
-          #materialGroupList, materialGroup
+          # materialGroupList, materialGroup
           mat_data = {
             'material' => 'material',
             'materialcomponentnote' => 'materialComponentNote'
           }
           mat_transforms = {
-            'material' => {'authority' => ['conceptauthorities', 'material_ca']}
+            'material' => { 'authority' => %w[conceptauthorities material_ca] }
           }
           CSXML.add_single_level_group_list(
             xml, attributes,
@@ -197,7 +202,7 @@ module CollectionSpace
             mat_data,
             mat_transforms
           )
-          #textualInscriptionGroupList,textualInscriptionGroup 
+          # textualInscriptionGroupList,textualInscriptionGroup
           textualinscriptiondata = {
             'publicartinscriptioncontent' => 'inscriptionContent',
             'publicartinscriptioncontentinscriberperson' => 'inscriptionContentInscriber',
@@ -214,11 +219,11 @@ module CollectionSpace
             'publicartinscriptioncontenttransliteration' => 'inscriptionContentTransliteration'
           }
           textualinscriptiontransforms = {
-            'publicartinscriptioncontentinscriberperson' => {'authority' => ['personauthorities', 'person']},
-            'publicartinscriptioncontentinscriberorganizationlocal' => {'authority' => ['orgauthorities', 'organization']},
-            'publicartinscriptioncontentinscriberorganizationshared' => {'authority' => ['orgauthorities', 'organization_shared']},
-            'publicartinscriptioncontentlanguage' => {'vocab' => 'languages'},
-            'publicartinscriptioncontentdategroup' => {'special' => 'structured_date'}
+            'publicartinscriptioncontentinscriberperson' => { 'authority' => %w[personauthorities person] },
+            'publicartinscriptioncontentinscriberorganizationlocal' => { 'authority' => %w[orgauthorities organization] },
+            'publicartinscriptioncontentinscriberorganizationshared' => { 'authority' => %w[orgauthorities organization_shared] },
+            'publicartinscriptioncontentlanguage' => { 'vocab' => 'languages' },
+            'publicartinscriptioncontentdategroup' => { 'special' => 'structured_date' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -227,15 +232,15 @@ module CollectionSpace
             textualinscriptiondata,
             textualinscriptiontransforms
           )
-          #objectProductionPersonGroupList, objectProductionPersonGroup
+          # objectProductionPersonGroupList, objectProductionPersonGroup
           objectprodpersondata = {
             'objectproductionpersonlocal' => 'objectProductionPerson',
             'objectproductionpersonshared' => 'objectProductionPerson',
             'objectproductionpersonrole' => 'objectProductionPersonRole'
           }
           objectprodpersontransforms = {
-            'objectproductionpersonlocal' => {'authority' => ['personauthorities', 'person']},
-            'objectproductionpersonshared' => {'authority' => ['personauthorities', 'person_shared']}
+            'objectproductionpersonlocal' => { 'authority' => %w[personauthorities person] },
+            'objectproductionpersonshared' => { 'authority' => %w[personauthorities person_shared] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -244,15 +249,15 @@ module CollectionSpace
             objectprodpersondata,
             objectprodpersontransforms
           )
-          #objectProductionOrganizationGroupList, objectProductionOrganizationGroup
+          # objectProductionOrganizationGroupList, objectProductionOrganizationGroup
           objectprodorgdata = {
             'objectproductionorganizationlocal' => 'objectProductionOrganization',
             'objectproductionorganizationshared' => 'objectProductionOrganization',
             'objectproductionorganizationrole' => 'objectProductionOrganizationRole'
           }
           objectprodorgtransforms = {
-            'objectproductionorganizationlocal' => {'authority' => ['orgauthorities', 'organization']},
-            'objectproductionorganizationshared' => {'authority' => ['orgauthorities', 'organization_shared']}
+            'objectproductionorganizationlocal' => { 'authority' => %w[orgauthorities organization] },
+            'objectproductionorganizationshared' => { 'authority' => %w[orgauthorities organization_shared] }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -263,22 +268,22 @@ module CollectionSpace
           )
         end
 
-        def self.map_publicart(xml, attributes)
+        def map_publicart(xml, attributes)
           repeats = {
-            'publicartcollection' => ['publicartCollections', 'publicartCollection']
+            'publicartcollection' => %w[publicartCollections publicartCollection]
           }
           repeat_transforms = {
-            'publicartcollection' => {'authority' => ['orgauthorities', 'organization']}
+            'publicartcollection' => { 'authority' => %w[orgauthorities organization] }
           }
           CSXML::Helpers.add_repeats(xml, attributes, repeats, repeat_transforms)
-          #publicartProductionDateGroupList, publicartProductionDateGroup
+          # publicartProductionDateGroupList, publicartProductionDateGroup
           ppd_data = {
             'publicartproductiondate' => 'publicartProductionDate',
             'publicartproductiondatetype' => 'publicartProductionDateType'
           }
           ppd_transforms = {
-            'publicartproductiondate' => {'special' => 'structured_date'},
-            'publicartproductiondatetype' => {'vocab' => 'proddatetype'}
+            'publicartproductiondate' => { 'special' => 'structured_date' },
+            'publicartproductiondatetype' => { 'vocab' => 'proddatetype' }
           }
           CSXML.add_single_level_group_list(
             xml,
@@ -287,21 +292,21 @@ module CollectionSpace
             ppd_data,
             ppd_transforms
           )
-          #publicartProductionPersonGrouplist, publicartProductionPersonGroup
+          # publicartProductionPersonGrouplist, publicartProductionPersonGroup
           ppp_data = {
             'publicartproductionpersontype' => 'publicartProductionPersonType',
             'publicartproductionpersonrole' => 'publicartProductionPersonRole',
             'publicartproductionpersonpersonlocal' => 'publicartProductionPerson',
             'publicartproductionpersonpersonshared' => 'publicartProductionPerson',
             'publicartproductionpersonorganizationlocal' => 'publicartProductionPerson',
-            'publicartproductionpersonorganizationshared' => 'publicartProductionPerson',
+            'publicartproductionpersonorganizationshared' => 'publicartProductionPerson'
           }
           ppp_transforms = {
-            'publicartproductionpersonrole' => {'vocab' => 'prodpersonrole'},
-            'publicartproductionpersonpersonlocal' => {'authority' => ['personauthorities', 'person']},
-            'publicartproductionpersonorganizationlocal' => {'authority' => ['orgauthorities', 'organization']},
-            'publicartproductionpersonpersonshared' => {'authority' => ['personauthorities', 'person_shared']},
-            'publicartproductionpersonorganizationshared' => {'authority' => ['orgauthorities', 'organization_shared']}
+            'publicartproductionpersonrole' => { 'vocab' => 'prodpersonrole' },
+            'publicartproductionpersonpersonlocal' => { 'authority' => %w[personauthorities person] },
+            'publicartproductionpersonorganizationlocal' => { 'authority' => %w[orgauthorities organization] },
+            'publicartproductionpersonpersonshared' => { 'authority' => %w[personauthorities person_shared] },
+            'publicartproductionpersonorganizationshared' => { 'authority' => %w[orgauthorities organization_shared] }
           }
           CSXML.add_single_level_group_list(
             xml, attributes,
@@ -311,6 +316,6 @@ module CollectionSpace
           )
         end # def self.map
       end # class PublicArtCollectionObject
-    end #module PublicArt
+    end # module PublicArt
   end # module Converter
 end # module CollectionSpace

--- a/lib/collectionspace/converter/publicart/media.rb
+++ b/lib/collectionspace/converter/publicart/media.rb
@@ -30,11 +30,11 @@ module CollectionSpace
           # publicartRightsHolders (two CSV columns, rights_holder_org and owners_org)
           #
           rightsholders_urns = []
-          rightsholders = split_mvf attributes, 'rightsholder_person'
+          rightsholders = CSXML.split_mvf attributes, 'rightsholder_person'
           rightsholders.each do | rightsholder |
             rightsholders_urns << { "publicartRightsHolder" => CSURN.get_authority_urn('personauthorities', 'person', rightsholder) }
           end
-          rightsholders = split_mvf attributes, 'rightsholder_org'
+          rightsholders = CSXML.split_mvf attributes, 'rightsholder_org'
           rightsholders.each do |rightsholder|
             rightsholders_urns << { "publicartRightsHolder" => CSURN.get_authority_urn('orgauthorities', 'organization', rightsholder) }
           end
@@ -44,7 +44,7 @@ module CollectionSpace
           # publishToList
           #
           publishto_urns = []
-          publishto_list = split_mvf attributes, 'publishto'
+          publishto_list = CSXML.split_mvf attributes, 'publishto'
           publishto_list.each do | publishto |
             publishto_urns << { "publishTo" => CSURN.get_vocab_urn('publishto', publishto) }
           end

--- a/lib/collectionspace/converter/publicart/place.rb
+++ b/lib/collectionspace/converter/publicart/place.rb
@@ -55,7 +55,7 @@ module CollectionSpace
         def self.extension(xml, attributes)
           # placementTypes
           placement_types_urns = []
-          placement_types = split_mvf attributes, 'placementtype'
+          placement_types = CSXML.split_mvf attributes, 'placementtype'
           placement_types.each do | placement_type |
             placement_types_urns << { "placementType" => CSURN.get_vocab_urn('placementtypes', placement_type) }
           end

--- a/spec/collectionspace/converter/anthro/collectionobject_spec.rb
+++ b/spec/collectionspace/converter/anthro/collectionobject_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe CollectionSpace::Converter::Anthro::AnthroCollectionObject do
   end
 
   let(:common) { 'collectionobjects_common' }
-  
+
   describe '#map' do
     let(:anthro) { 'collectionobjects_anthro' }
 
@@ -37,7 +37,7 @@ RSpec.describe CollectionSpace::Converter::Anthro::AnthroCollectionObject do
           { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[1]/behrensmeyerUpper", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
           { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[2]/behrensmeyerUpper", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
           { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[1]/behrensmeyerSingleLower", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
-          { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[2]/behrensmeyerSingleLower", transform: ->(text) {CSURN.parse(text)[:label].downcase} },    
+          { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[2]/behrensmeyerSingleLower", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
           "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup/commingledRemainsNote",
           "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup/sex",
           "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup/count",
@@ -72,13 +72,13 @@ RSpec.describe CollectionSpace::Converter::Anthro::AnthroCollectionObject do
         xpath = "/document/#{common}/objectProductionPeopleGroupList/objectProductionPeopleGroup[2]/objectProductionPeople"
         result = get_text(doc, xpath)
         expect(result).to include('conceptauthorities:name(archculture)')
-      end 
+      end
       it 'Maps overrides to objectProductionPeopleRole to vocab: prodpeoplerole' do
         xpath = "/document/#{common}/objectProductionPeopleGroupList/objectProductionPeopleGroup[2]/objectProductionPeopleRole"
         result = get_text(doc, xpath)
         expect(result).to include('vocabularies:name(prodpeoplerole)')
       end
-     
+
     end #  context 'sample data row 2'
   end # describe #map
 
@@ -120,7 +120,7 @@ RSpec.describe CollectionSpace::Converter::Anthro::AnthroCollectionObject do
           { xpath: "/document/#{nagpra}/nagpraCategories/nagpraCategory[1]", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
           { xpath: "/document/#{nagpra}/nagpraCategories/nagpraCategory[2]", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
           "/document/#{nagpra}/nagpraReportFiledDate/dateLatestScalarValue",
-          "/document/#{nagpra}/nagpraReportFiledDate/dateEarliestScalarValue"          
+          "/document/#{nagpra}/nagpraReportFiledDate/dateEarliestScalarValue"
         ]}
 
         it "Maps attributes correctly" do
@@ -142,8 +142,8 @@ RSpec.describe CollectionSpace::Converter::Anthro::AnthroCollectionObject do
         end
       end
     end # describe #map
-    
-    describe '#map_cultural_care' do      
+
+    describe '#map_cultural_care' do
       context 'sample data row 8 - culturalcare extension only' do
         let(:attributes) { get_attributes_by_row('anthro', 'collectionobject_partial.csv', 8) }
         let(:anthrocollectionobject) { AnthroCollectionObject.new(attributes) }
@@ -165,5 +165,5 @@ RSpec.describe CollectionSpace::Converter::Anthro::AnthroCollectionObject do
         end
       end
     end # describe #map
-    
+
 end

--- a/spec/collectionspace/converter/core/collectionobject_spec.rb
+++ b/spec/collectionspace/converter/core/collectionobject_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe CollectionSpace::Converter::Core::CoreCollectionObject do
     '/document/*/contentPeoples/contentPeople',
     '/document/*/contentPlaces/contentPlace',
     '/document/*/contentScripts/contentScript',
-    { xpath: '/document/*/contentOrganizations/contentOrganization', transform: ->(text) { CSURN.parse(text)[:label] } }, 
+    { xpath: '/document/*/contentOrganizations/contentOrganization', transform: ->(text) { CSURN.parse(text)[:label] } },
     { xpath: '/document/*/textualInscriptionGroupList/textualInscriptionGroup/inscriptionContentInscriber', transform: ->(text) { CSURN.parse(text)[:label] } },
     '/document/*/textualInscriptionGroupList/textualInscriptionGroup/inscriptionContentMethod',
     { xpath: '/document/*/objectProductionOrganizationGroupList/objectProductionOrganizationGroup[1]/objectProductionOrganization',  transform: ->(text) { CSURN.parse(text)[:label] } },
@@ -209,18 +209,18 @@ RSpec.describe CollectionSpace::Converter::Core::CoreCollectionObject do
     '/document/*/nonTextualInscriptionGroupList/nonTextualInscriptionGroup/inscriptionDescriptionMethod',
     '/document/*/nonTextualInscriptionGroupList/nonTextualInscriptionGroup/inscriptionDescriptionInterpretation',
   ]}
-  
+
   context 'For maximally populuated record' do
     it "Maps attributes correctly" do
       test_converter(doc, record, xpaths)
     end
   end
-  
+
   context 'For minimally populated record' do
     let(:attributes) { get_attributes_by_row('core', 'cataloging_core_excerpt.csv', 102) }
     let(:corecollectionobject) { CoreCollectionObject.new(attributes) }
     let(:doc) { Nokogiri::XML(corecollectionobject.convert, nil, 'UTF-8') }
-    let(:record) { get_fixture('core_collectionobject_row102.xml') }     
+    let(:record) { get_fixture('core_collectionobject_row102.xml') }
     let(:xpath_required) {[
       '/document/*/objectNumber'
     ]}

--- a/spec/collectionspace/converter/ohc/collectionobject_spec.rb
+++ b/spec/collectionspace/converter/ohc/collectionobject_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CollectionSpace::Converter::OHC::OHCCollectionObject do
         ]
         test_converter(doc, record, xpaths)
       end
-      
+
 
       it "Remaps objectNameGroups correctly" do
         xpaths = [
@@ -126,7 +126,7 @@ RSpec.describe CollectionSpace::Converter::OHC::OHCCollectionObject do
       { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[1]/behrensmeyerUpper", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
       { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[2]/behrensmeyerUpper", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
       { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[1]/behrensmeyerSingleLower", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
-      { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[2]/behrensmeyerSingleLower", transform: ->(text) {CSURN.parse(text)[:label].downcase} },    
+      { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[2]/behrensmeyerSingleLower", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
       "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup/minIndividuals",
       { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[1]/mortuaryTreatmentGroupList/mortuaryTreatmentGroup[1]/mortuaryTreatment", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
       { xpath: "/document/#{anthro}/commingledRemainsGroupList/commingledRemainsGroup[2]/mortuaryTreatmentGroupList/mortuaryTreatmentGroup[1]/mortuaryTreatment", transform: ->(text) {CSURN.parse(text)[:label].downcase} },
@@ -137,5 +137,5 @@ RSpec.describe CollectionSpace::Converter::OHC::OHCCollectionObject do
       test_converter(doc, record, xpaths)
     end
   end
-  
+
 end

--- a/spec/collectionspace/converter/publicart/collectionobject_spec.rb
+++ b/spec/collectionspace/converter/publicart/collectionobject_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject do
@@ -14,7 +16,6 @@ RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject 
   let(:doc) { get_doc(pacollectionobject) }
   let(:record) { get_fixture('publicart_collectionobject.xml') }
 
-  
   describe '#map_common' do
     common = 'collectionobjects_common'
     context 'fields not included in publicart' do
@@ -108,16 +109,16 @@ RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject 
         "/document/#{common}/nonTextualInscriptionGroupList/nonTextualInscriptionGroup/inscriptionDescriptionDateGroup/dateDisplayDate",
         "/document/#{common}/assocDateGroupList/assocDateGroup/assocStructuredDateGroup/dateDisplayDate",
         "/document/#{common}/ownershipDateGroupList/ownershipDateGroup/dateDisplayDate",
-        "/document/#{common}/fieldCollectionDateGroup/dateDisplayDate",
+        "/document/#{common}/fieldCollectionDateGroup/dateDisplayDate"
       ].each do |xpath|
-        context "#{xpath}" do
+        context xpath.to_s do
           it 'is empty' do
             verify_field_is_empty(doc, xpath)
           end
         end
       end
     end
-      
+
     context 'authority/vocab fields' do
       [
         "/document/#{common}/responsibleDepartments/responsibleDepartment",
@@ -125,10 +126,10 @@ RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject 
         "/document/#{common}/materialGroupList/materialGroup/material",
         "/document/#{common}/textualInscriptionGroupList/textualInscriptionGroup/inscriptionContentInscriber",
         "/document/#{common}/objectProductionPersonGroupList/objectProductionPersonGroup/objectProductionPerson",
-        "/document/#{common}/objectProductionOrganizationGroupList/objectProductionOrganizationGroup/objectProductionOrganization", 
-        "/document/#{common}/owners/owner",
+        "/document/#{common}/objectProductionOrganizationGroupList/objectProductionOrganizationGroup/objectProductionOrganization",
+        "/document/#{common}/owners/owner"
       ].each do |xpath|
-        context "#{xpath}" do
+        context xpath.to_s do
           let(:urn_vals) { urn_values(doc, xpath) }
           it 'is not empty' do
             verify_field_is_populated(doc, xpath)
@@ -137,13 +138,13 @@ RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject 
           it 'values are URNs' do
             verify_values_are_urns(urn_vals)
           end
-          
+
           it 'URNs match sample payload' do
             verify_urn_match(urn_vals, record, xpath)
           end
         end
-  end
-  end
+      end
+    end
   end
 
   describe '#map_publicart' do
@@ -155,7 +156,7 @@ RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject 
         "/document/#{pa}/publicartProductionPersonGroupList/publicartProductionPersonGroup/publicartProductionPersonRole",
         "/document/#{pa}/publicartProductionDateGroupList/publicartProductionDateGroup/publicartProductionDateType"
       ].each do |xpath|
-        context "#{xpath}" do
+        context xpath.to_s do
           let(:urn_vals) { urn_values(doc, xpath) }
           it 'is not empty' do
             verify_field_is_populated(doc, xpath)
@@ -164,7 +165,7 @@ RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject 
           it 'values are URNs' do
             verify_values_are_urns(urn_vals)
           end
-          
+
           it 'URNs match sample payload' do
             verify_urn_match(urn_vals, record, xpath)
           end
@@ -172,13 +173,11 @@ RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject 
       end
     end
 
-    
-
     context 'structured date fields' do
       [
         "/document/#{pa}/publicartProductionDateGroupList/publicartProductionDateGroup/publicartProductionDate"
       ].each do |xpath|
-        context "#{xpath}" do
+        context xpath.to_s do
           it 'is not empty' do
             expect(doc.xpath(xpath).size).to_not eq(0)
           end
@@ -191,19 +190,19 @@ RSpec.describe CollectionSpace::Converter::PublicArt::PublicArtCollectionObject 
     end
 
     context 'non-authority/vocab fields' do
-        [
+      [
         "/document/#{pa}/publicartProductionPersonGroupList/publicartProductionPersonGroup/publicartProductionPersonType"
-        ].each do |xpath|
-          context "#{xpath}" do
-            it 'is not empty' do
-              verify_field_is_populated(doc, xpath)
-            end
-            
-            it 'matches sample payload' do
-              verify_value_match(doc, record, xpath)
-            end
+      ].each do |xpath|
+        context xpath.to_s do
+          it 'is not empty' do
+            verify_field_is_populated(doc, xpath)
+          end
+
+          it 'matches sample payload' do
+            verify_value_match(doc, record, xpath)
           end
         end
       end
+    end
   end
 end


### PR DESCRIPTION
Start to transition away from global class methods to use conventional
inheritance instead. This works in parallel with the current system.

This will eventually lead to a decoupling of the transformer modules
from the converter tool so they could be gem-ified and re-used in
other projects.