### PR TITLE
Allow deleting fields

### DIFF
--- a/lib/collectionspace/converter/default/record.rb
+++ b/lib/collectionspace/converter/default/record.rb
@@ -49,12 +49,18 @@ module CollectionSpace
             }
           end
           traverse_and_clean(builder.doc)
+          clear_deleted_fields(builder.doc)
           builder.to_xml.to_s.gsub(/(<\/?)(\w+_)/, '\1ns2:\2')
         end
 
         def traverse_and_clean(node)
           node.children.map { |child| traverse_and_clean(child) }
           node.remove if node.content.blank? && node.attributes.blank?
+        end
+
+        def clear_deleted_fields(node)
+          node.children.map { |child| clear_deleted_fields(child) }
+          node.content = '' if node.content.match('💣')
         end
 
         def self.service(subtype = nil)


### PR DESCRIPTION
I don't know if this should actually merged, because it's the epitome of quick and dirty, but it works. :-)   All it does is go through the document tree after the empty nodes are deleted and clear any text node that has a 💣 anywhere in it.

Hoping @kspurgin is amused.   